### PR TITLE
D3d4/research/surface heat transfer

### DIFF
--- a/src/engines_gpl/flow2d3d/packages/flow2d3d_data/include/heat.igs
+++ b/src/engines_gpl/flow2d3d/packages/flow2d3d_data/include/heat.igs
@@ -91,6 +91,7 @@ type gd_heat
     real(fp)                :: dtrain    !  Time increment of the rain temperature
     real(fp)                :: mulsd     !  Multiplier for the Secchi depth to obtain the Shallow Secchi depth (range 0.01--1)
     real(fp)                :: betasd    !  Fraction of the solar radiation that penetrates deep (range 0--1)
+    real(fp)                :: beta_sw   !  Fraction of the solar radiation that is absorbed at the surface (range 0--1)
     real(fp)                :: albedo    !  Albedo coefficient 
 ! reals
 !

--- a/src/engines_gpl/flow2d3d/packages/flow2d3d_io/src/input/rdproc.f90
+++ b/src/engines_gpl/flow2d3d/packages/flow2d3d_io/src/input/rdproc.f90
@@ -57,6 +57,7 @@ subroutine rdproc(error    ,nrrec     ,mdfrec    ,htur2d      ,salin    , &
     !
     ! The following list of pointer parameters is used to point inside the gdp structure
     !
+    real(fp)                   , pointer :: betasd
     real(fp)                   , pointer :: cfrcon
     real(fp)                   , pointer :: cp
     real(fp)                   , pointer :: sarea
@@ -177,6 +178,7 @@ subroutine rdproc(error    ,nrrec     ,mdfrec    ,htur2d      ,salin    , &
 !
 !! executable statements -------------------------------------------------------
 !
+    betasd              => gdp%gdheat%betasd
     cfrcon              => gdp%gdheat%cfrcon
     cp                  => gdp%gdheat%cp
     sarea               => gdp%gdheat%sarea
@@ -648,6 +650,27 @@ subroutine rdproc(error    ,nrrec     ,mdfrec    ,htur2d      ,salin    , &
              free_convec = .false.
           else
              write(message,'(a,f12.3)') 'Specified free convection coefficient cfrcon = ', cfrcon
+             call prterr(lundia, 'G051', trim(message))
+          endif
+          !
+          ! reset sprval
+          !
+          sprval = 0.0_sp
+          !
+          ! Locate and read 'betasd'
+          ! default value is 0.3
+          !
+          sprval = -999.0_sp
+          !
+          ! betasd is used by default
+          call prop_get_real(gdp%mdfile_ptr, '*', 'betasd', sprval)
+          betasd = real(sprval, fp)
+          if (comparereal(betasd, -999.0_fp) == 0) then
+             betasd = 0.30_fp
+             write(message, '(a,f12.3)') 'Ocean heat model: Using default betasd ', betasd
+             call prterr(lundia, 'G051', trim(message))
+          else
+             write(message,'(a,f12.3)') 'Specified beta coefficient for surface absorption of shortwave radiation = ', betasd
              call prterr(lundia, 'G051', trim(message))
           endif
           !

--- a/src/engines_gpl/flow2d3d/packages/flow2d3d_io/src/input/rdproc.f90
+++ b/src/engines_gpl/flow2d3d/packages/flow2d3d_io/src/input/rdproc.f90
@@ -666,7 +666,7 @@ subroutine rdproc(error    ,nrrec     ,mdfrec    ,htur2d      ,salin    , &
           call prop_get_real(gdp%mdfile_ptr, '*', 'beta_sw', sprval)
           beta_sw = real(sprval, fp)
           if (comparereal(beta_sw, -999.0_fp) == 0) then
-             beta_sw = 0.30_fp
+             beta_sw = 0.00_fp
              write(message, '(a,f12.3)') 'Ocean heat model: Using default beta_sw ', beta_sw
              call prterr(lundia, 'G051', trim(message))
           else

--- a/src/engines_gpl/flow2d3d/packages/flow2d3d_io/src/input/rdproc.f90
+++ b/src/engines_gpl/flow2d3d/packages/flow2d3d_io/src/input/rdproc.f90
@@ -57,7 +57,7 @@ subroutine rdproc(error    ,nrrec     ,mdfrec    ,htur2d      ,salin    , &
     !
     ! The following list of pointer parameters is used to point inside the gdp structure
     !
-    real(fp)                   , pointer :: betasd
+    real(fp)                   , pointer :: beta_sw
     real(fp)                   , pointer :: cfrcon
     real(fp)                   , pointer :: cp
     real(fp)                   , pointer :: sarea
@@ -178,7 +178,7 @@ subroutine rdproc(error    ,nrrec     ,mdfrec    ,htur2d      ,salin    , &
 !
 !! executable statements -------------------------------------------------------
 !
-    betasd              => gdp%gdheat%betasd
+    beta_sw              => gdp%gdheat%beta_sw
     cfrcon              => gdp%gdheat%cfrcon
     cp                  => gdp%gdheat%cp
     sarea               => gdp%gdheat%sarea
@@ -657,20 +657,20 @@ subroutine rdproc(error    ,nrrec     ,mdfrec    ,htur2d      ,salin    , &
           !
           sprval = 0.0_sp
           !
-          ! Locate and read 'betasd'
+          ! Locate and read 'beta_sw'
           ! default value is 0.3
           !
           sprval = -999.0_sp
           !
-          ! betasd is used by default
-          call prop_get_real(gdp%mdfile_ptr, '*', 'betasd', sprval)
-          betasd = real(sprval, fp)
-          if (comparereal(betasd, -999.0_fp) == 0) then
-             betasd = 0.30_fp
-             write(message, '(a,f12.3)') 'Ocean heat model: Using default betasd ', betasd
+          ! beta_sw is used by default
+          call prop_get_real(gdp%mdfile_ptr, '*', 'beta_sw', sprval)
+          beta_sw = real(sprval, fp)
+          if (comparereal(beta_sw, -999.0_fp) == 0) then
+             beta_sw = 0.30_fp
+             write(message, '(a,f12.3)') 'Ocean heat model: Using default beta_sw ', beta_sw
              call prterr(lundia, 'G051', trim(message))
           else
-             write(message,'(a,f12.3)') 'Specified beta coefficient for surface absorption of shortwave radiation = ', betasd
+             write(message,'(a,f12.3)') 'Specified beta coefficient for surface absorption of shortwave radiation = ', beta_sw
              call prterr(lundia, 'G051', trim(message))
           endif
           !

--- a/src/engines_gpl/flow2d3d/packages/flow2d3d_kernel/src/compute/heatu.f90
+++ b/src/engines_gpl/flow2d3d/packages/flow2d3d_kernel/src/compute/heatu.f90
@@ -1213,7 +1213,7 @@ do l=1,lstsci
                 !
                 extinc = 1.7_fp/secchi(nm)
                 corr  = 1.0_fp / ( (1.0_fp - exp(extinc*zbottom)) / extinc )
-                qink  = corr * qsn * (1.0_fp - exp(extinc*zdown)) / extinc
+                qink  = corr * (1.0_fp-betasd) *qsn * (1.0_fp - exp(extinc*zdown)) / extinc + qsn * betasd
                 qtotk = (qink-ql) / (rhow*cp)
                 !
                 ! Reduction of solar radiation at shallow areas
@@ -1254,7 +1254,7 @@ do l=1,lstsci
                    else
                       zdown = zdown - thick(k)*h0old
                    endif
-                   qink  = corr * qsn * (exp(extinc*ztop) - exp(extinc*zdown)) / extinc
+                   qink  = corr * (1.0_fp-betasd) * qsn * (exp(extinc*ztop) - exp(extinc*zdown)) / extinc
                    qtotk = qink / (rhow*cp)
                    if (zmodel) then
                       sour(nm, k, l) = sour(nm, k, l) + qtotk*gsqs(nm)

--- a/src/engines_gpl/flow2d3d/packages/flow2d3d_kernel/src/compute/heatu.f90
+++ b/src/engines_gpl/flow2d3d/packages/flow2d3d_kernel/src/compute/heatu.f90
@@ -76,6 +76,7 @@ subroutine heatu(ktemp     ,anglat    ,sferic    ,timhr     ,keva      , &
     real(fp)                , pointer :: dalton
     real(fp)                , pointer :: mulsd
     real(fp)                , pointer :: betasd
+    real(fp)                , pointer :: beta_sw
     real(fp)                , pointer :: albedo
     real(fp)                , pointer :: qtotmx
     real(fp)                , pointer :: lambda
@@ -276,6 +277,7 @@ subroutine heatu(ktemp     ,anglat    ,sferic    ,timhr     ,keva      , &
     dalton      => gdp%gdheat%dalton
     mulsd       => gdp%gdheat%mulsd
     betasd      => gdp%gdheat%betasd
+    beta_sw     => gdp%gdheat%beta_sw
     albedo      => gdp%gdheat%albedo
     qtotmx      => gdp%gdheat%qtotmx
     lambda      => gdp%gdheat%lambda
@@ -1213,7 +1215,7 @@ do l=1,lstsci
                 !
                 extinc = 1.7_fp/secchi(nm)
                 corr  = 1.0_fp / ( (1.0_fp - exp(extinc*zbottom)) / extinc )
-                qink  = corr * (1.0_fp-betasd) *qsn * (1.0_fp - exp(extinc*zdown)) / extinc + qsn * betasd
+                qink  = corr * (1.0_fp-beta_sw) *qsn * (1.0_fp - exp(extinc*zdown)) / extinc + qsn * beta_sw
                 qtotk = (qink-ql) / (rhow*cp)
                 !
                 ! Reduction of solar radiation at shallow areas
@@ -1254,7 +1256,7 @@ do l=1,lstsci
                    else
                       zdown = zdown - thick(k)*h0old
                    endif
-                   qink  = corr * (1.0_fp-betasd) * qsn * (exp(extinc*ztop) - exp(extinc*zdown)) / extinc
+                   qink  = corr * (1.0_fp-beta_sw) * qsn * (exp(extinc*ztop) - exp(extinc*zdown)) / extinc
                    qtotk = qink / (rhow*cp)
                    if (zmodel) then
                       sour(nm, k, l) = sour(nm, k, l) + qtotk*gsqs(nm)


### PR DESCRIPTION
Improve heat transfer computation at the surface and interior.

Shift from distribution of total solar radiation using an extinction co-efficient to retaining a fraction of the incoming shortwave solar radiation (qsn) at the surface layer and distributing the remaining according to an exponential.

The former parametrization induces unrealistic cooling at the surface layer, where not enough solar radiation is absorbed as outgoing heat fluxes are extracted. This was identified by verifying that the best representation of observed surface water temperature was achieved by minimizing the Secchi depth parameter, which is physically not consistent and leads to an incorrect representation of the deeper layers. 

This has been fixed by introducing a new parameter (beta_sw) in heat model 5 and adjusting how the total incoming heat is computed at the surface layer and in the interior. This allows Secchi depth to correctly parameterize the heating in the euphotic zone and the surface layer. This reformulation is in alignment with other lake models such as SIMSTRAT ([doi:10.1029/2001JC000954](http://doi.org/10.1029/2001JC000954)).